### PR TITLE
Actualización importante de wpm_jobs.sh y subida menor de versión

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -150,8 +150,8 @@ start_service() {
     echo "Service started and enabled"
 }
 
-# Update paths in wpm_jobs.sh
-update_wpm_jobs_paths() {
+# Update paths and panel in wpm_jobs.sh
+update_wpm_jobs_file() {
     WPM_JOBS_FILE="$BASE_DIR/wpm_bash/wpm_jobs.sh"
 
     # Ensure the wpm_jobs.sh file exists
@@ -160,10 +160,14 @@ update_wpm_jobs_paths() {
         exit 1
     fi
 
-    # Update paths in wpm_jobs.sh
+    # Detect the control panel
+    cp=$(detect_control_panel)
+
+    # Update paths and panel in wpm_jobs.sh
     sed -i "s|^JOBS_FILE=.*|JOBS_FILE=\"$BASE_DIR/wp_monitor/jobs\"|" "$WPM_JOBS_FILE"
     sed -i "s|^JOBS_EXECUTED_FILE=.*|JOBS_EXECUTED_FILE=\"$BASE_DIR/jobs_executed\"|" "$WPM_JOBS_FILE"
     sed -i "s|^LOCK_FILE=.*|LOCK_FILE=\"$BASE_DIR/wpm_data/tmp/wp_monitor.lock\"|" "$WPM_JOBS_FILE"
+    sed -i "s|^PANEL=.*|PANEL=\"$cp\"|" "$WPM_JOBS_FILE"
 }
 
 # 1. Detect control panel
@@ -220,9 +224,9 @@ else
     fi
 fi
 
-echo "Permissions to 'jobs' file will be applied "
+echo "Permissions to 'jobs' file will be applied $user_group"
 if [ "$check" = false ]; then
-    chown -R "$user_group" "$BASE_DIR/wpm_data"
+    chown "$user_group" "$BASE_DIR/jobs"
 fi
 
 echo "Permissions will be applied $user_group a $BASE_DIR/wpm_data"
@@ -233,7 +237,7 @@ fi
 # Modify BASE_DIR in wpm_bash/wpm_jobs.sh
 echo "BASE_DIR updated in wpm_bash/wpm_jobs.sh"
 if [ "$check" = false ]; then
-    update_wpm_jobs_paths
+    update_wpm_jobs_file
 fi
 
 # Modify USER_GROUP in CRON scripts

--- a/wpm_bash/wpm_jobs.sh
+++ b/wpm_bash/wpm_jobs.sh
@@ -4,6 +4,7 @@
 JOBS_FILE="/opt/wp_monitor/jobs"
 JOBS_EXECUTED_FILE="/opt/wp_monitor/jobs_executed"
 LOCK_FILE="/opt/wp_monitor/wpm_data/tmp/wp_monitor.lock"
+PANEL=""
 
 # Record the result of a job
 log_job_execution() {
@@ -13,12 +14,16 @@ log_job_execution() {
     echo "$timestamp - $job - $status" >> $JOBS_EXECUTED_FILE
 }
 
-# uUpdate WordPress version
+# Update WordPress version
 update_wordpress() {
     local wp_id=$1
     local job="Update WordPress ID $wp_id"
     echo "Updating WordPress for ID installation $wp_id"
-    response=$(wp-toolkit --update $wp_id 2>&1)
+    if [ "$PANEL" = "2" ]; then
+        response=$(/usr/sbin/plesk ext wp-toolkit --update $wp_id 2>&1)
+    elif [ "$PANEL" = "1" ]; then
+        response=/usr/local/bin/wp-toolkit --update $wp_id 2>&1
+    fi
     if [ $? -eq 0 ]; then
         log_job_execution "$job" "Success"
     else
@@ -32,7 +37,11 @@ update_plugin() {
     local plugin_name=$2
     local job="Update plugin $plugin_name for installation ID $wp_id"
     echo "Updating plugin $plugin_name for installation ID $wp_id"
-    response=$(wp-toolkit --plugin update $wp_id --name=$plugin_name 2>&1)
+    if [ "$PANEL" = "2" ]; then
+        response=$(/usr/sbin/plesk ext wp-toolkit --plugin update $wp_id --name=$plugin_name 2>&1)
+    elif [ "$PANEL" = "1" ]; then
+        response=/usr/local/bin/wp-toolkit --plugin update $wp_id --name=$plugin_name 2>&1
+    fi
     if [ $? -eq 0 ]; then
         log_job_execution "$job" "Success"
     else
@@ -46,7 +55,11 @@ update_template() {
     local template_name=$2
     local job="Update template $template_name for installation ID $wp_id"
     echo "Updating template $template_name for installation ID $wp_id"
-    response=$(wp-toolkit --theme update $wp_id --name=$template_name 2>&1)
+    if [ "$PANEL" = "2" ]; then
+        response=$(/usr/sbin/plesk ext wp-toolkit --theme update $wp_id --name=$template_name 2>&1)
+    elif [ "$PANEL" = "1" ]; then
+        response=/usr/local/bin/wp-toolkit --theme update $wp_id --name=$template_name 2>&1
+    fi
     if [ $? -eq 0 ]; then
         log_job_execution "$job" "Success"
     else
@@ -60,7 +73,11 @@ disable_plugin() {
     local plugin_name=$2
     local job="Disable plugin $plugin_name for installation ID $wp_id"
     echo "Disabling plugin $plugin_name for installation ID $wp_id"
-    response=$(wp-toolkit --plugin deactivate $wp_id --name=$plugin_name 2>&1)
+    if [ "$PANEL" = "2" ]; then
+        response=$(/usr/sbin/plesk ext wp-toolkit --plugin deactivate $wp_id --name=$plugin_name 2>&1)
+    elif [ "$PANEL" = "1" ]; then
+        response=/usr/local/bin/wp-toolkit --plugin deactivate $wp_id --name=$plugin_name 2>&1
+    fi
     if [ $? -eq 0 ]; then
         log_job_execution "$job" "Success"
     else


### PR DESCRIPTION
Se ha cambiado completamente wpm_jobs.sh ya que no determinaba bajo que Panel de Control se ejecutaba por lo que los jobs no funcionaban. También se modifica el nombre de la función update_wpm_jobs_paths por update_wpm_jobs_file, ya que ahora además de modificar los paths también establece la variable PANEL en el archivo wpm_jobs.sh